### PR TITLE
build version 2.12.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.13.1" %}
+{% set version = "2.12.3" %}
 {% set name = "pytensor" %}
 
 package:


### PR DESCRIPTION
this PR is very similar to [#1](https://github.com/AnacondaRecipes/pytensor-suite-feedstock/pull/1), all comments there apply to this one, except in this case an older version is built to satisfy a dependency on this specific version.