### PR TITLE
build version to 2.12.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+upload_without_merge: true
+aggregate_check: false
+upload_channels:
+  - boldorider4_test_channel
+channels:
+  - boldorider4_test_channel

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,6 @@
 upload_without_merge: true
 aggregate_check: false
 upload_channels:
-  - boldorider4_test_channel
+  - boldorider4-test-channel
 channels:
-  - boldorider4_test_channel
+  - boldorider4-test-channel

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-upload_without_merge: true
-aggregate_check: false
-upload_channels:
-  - boldorider4-test-channel
-channels:
-  - boldorider4-test-channel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pymc-devs/{{ name }}/archive/refs/tags/rel-{{ version }}.tar.gz
-  sha256: 468eb208e5a9fe62530752a354f48f739442b45811797e084ea432809ca5f99c
+  sha256: a1c436c67376436d2030742434cae7ff450a07c207c352f26ac958b0fb60142e
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.13.1" %}
+{% set version = "2.12.3" %}
 {% set name = "pytensor" %}
 
 package:


### PR DESCRIPTION
this stems from [PR#1](https://github.com/AnacondaRecipes/pytensor-feedstock/pull/1) but in this PR we build a versioned feedstock to satisfy dependencies on `pytensor < 2.13`.

[pyproject.toml](https://github.com/pymc-devs/pytensor/blob/rel-2.12.3/pyproject.toml) doesn't seem to have changed between 2.12.3 and 2.13.1 (which was built in [PR#1](https://github.com/AnacondaRecipes/pytensor-feedstock/pull/1)).
