### PR TITLE
pytensor 2.23.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.13.1" %}
+{% set version = "2.23.0" %}
 {% set name = "pytensor" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pymc-devs/{{ name }}/archive/refs/tags/rel-{{ version }}.tar.gz
-  sha256: 468eb208e5a9fe62530752a354f48f739442b45811797e084ea432809ca5f99c
+  sha256: 543eebd466db93190ac454c5a633948f724a64021e4fe39d89344e7423a5798b
 
 build:
   number: 0
@@ -15,6 +15,7 @@ build:
     - python -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - pytensor-cache = bin.pytensor_cache:main
+  skip: True #  [py<=310]
 
 requirements:
   build:
@@ -59,7 +60,6 @@ test:
     - check-for-warnings.py
     - allowed-warnings-base.txt
   commands:
-    - pytensor-cache help
     - pip check
     - python check-for-warnings.py allowed-warnings-base.txt
     - python -m pytest tests/test_breakpoint.py tests/test_config.py tests/test_gradient.py tests/test_ifelse.py tests/test_raise_op.py tests/test_rop.py tests/test_updates.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   script:
     - python -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
-    - pytensor-cache = bin.pytensor_cache:main
+    - pytensor-cache = pytensor.bin.pytensor_cache:main
   skip: True #  [py<=310]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,6 +61,7 @@ test:
     - allowed-warnings-base.txt
   commands:
     - pip check
+    - pytensor-cache help
     - python check-for-warnings.py allowed-warnings-base.txt
     - python -m pytest tests/test_breakpoint.py tests/test_config.py tests/test_gradient.py tests/test_ifelse.py tests/test_raise_op.py tests/test_rop.py tests/test_updates.py
     - python -m pytest tests/test_printing.py  # [osx]
@@ -75,7 +76,7 @@ about:
     PyTensor is a Python library that allows you to define, optimize/rewrite, and evaluate mathematical expressions
     involving multi-dimensional arrays efficiently.
   dev_url: https://github.com/pymc-devs/pytensor/
-  doc_url: https://pytensor.readthedocs.io/en/latest/
+  doc_url: https://pytensor.readthedocs.io
 
 extra:
   recipe-maintainers:
@@ -86,4 +87,3 @@ extra:
   skip-lints:
     - host_section_needs_exact_pinnings
     - python_build_tool_in_run
-    - documentation_specifies_language


### PR DESCRIPTION
pytensor 2.23.0

**Destination channel:** defaults

### Links

- [PKG-5198](https://anaconda.atlassian.net/browse/PKG-5198) 
- [Upstream repository](https://github.com/pymc-devs/pytensor)
- [Upstream changelog/diff](https://github.com/pymc-devs/pytensor/compare/rel-2.13.1...rel-2.23.0)

### Explanation of changes:

- Updated entry-point


[PKG-5198]: https://anaconda.atlassian.net/browse/PKG-5198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ