### PR TITLE
pytensor 2.23.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 543eebd466db93190ac454c5a633948f724a64021e4fe39d89344e7423a5798b
 
 build:
-  number: 1
+  number: 2
   script:
     - python -m pip install . -vv --no-deps --no-build-isolation
   entry_points:


### PR DESCRIPTION
pytensor 2.23.0 

**Destination channel:** Default

### Links

- [PKG-6364]
- dev_url:        https://github.com/pymc-devs/pytensor/tree/rel-2.23.0
- conda_forge:    None
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

- new version number


[PKG-6364]: https://anaconda.atlassian.net/browse/PKG-6364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ