### PR TITLE
rebuild 2.12.3 with cxx

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 1
+  # skip py312 because of numpy 1.26 incompatibility
+  skip: True  # [py>311]
   script:
     - python -m pip install . -vv --no-deps --no-build-isolation
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy <1.26
+    - {{ pin_compatible('numpy') }}
     - scipy >=0.14
     - filelock
     - etuples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy <1.26
+    - {{ pin_compatible('numpy', upper_bound='1.26') }}
     - scipy >=0.14
     - filelock
     - etuples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,6 +65,8 @@ test:
   commands:
     - pytensor-cache help
     - pip check
+    # this flag prevents a known issue with macOS clang++ throwing errors when narrowing types in implicit casts
+    - export PYTENSOR_FLAGS="gcc__cxxflags=-Wno-c++11-narrowing"  # [osx]
     - python check-for-warnings.py allowed-warnings-base.txt
     - python -m pytest tests/test_breakpoint.py tests/test_config.py tests/test_gradient.py tests/test_ifelse.py tests/test_raise_op.py tests/test_rop.py tests/test_updates.py
     - python -m pytest tests/test_printing.py  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,7 @@ requirements:
     - wheel
   run:
     - python
-    #- {{ pin_compatible('numpy') }}
-    - numpy {{ numpy }}
+    - numpy <1.26
     - scipy >=0.14
     - filelock
     - etuples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy {{ numpy }}, <1.26
+    - numpy <1.26
     - scipy >=0.14
     - filelock
     - etuples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - wheel
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy {{ numpy }}, <1.26
     - scipy >=0.14
     - filelock
     - etuples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a1c436c67376436d2030742434cae7ff450a07c207c352f26ac958b0fb60142e
 
 build:
-  number: 0
+  number: 1
   script:
     - python -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
@@ -41,6 +41,8 @@ requirements:
     - cons
     - typing_extensions
     - setuptools >=48.0.0
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,8 @@ requirements:
     - wheel
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    #- {{ pin_compatible('numpy') }}
+    - numpy {{ numpy }}
     - scipy >=0.14
     - filelock
     - etuples


### PR DESCRIPTION
pytensor 2.12.3

**Destination channel:** Default

### Links

- [PKG-6364]
- dev_url:        https://github.com/pymc-devs/pytensor//tree/rel-2.12.3
- conda_forge:    None
- pypi:           https://pypi.org/project/pytensor/2.23.0
- pypi inspector: https://inspector.pypi.io/project/pytensor/2.12.3

### Related PRs
- https://github.com/AnacondaRecipes/causalimpact-feedstock/pull/1
- https://github.com/AnacondaRecipes/pytensor-feedstock/pull/5

### Explanation of changes:

- `compiler('c')` and `compiler('cxx')` was added in run to support the compilation of code at runtime
- added a flag preventing a known issue with macOS clang++ throwing errors when narrowing types in implicit casts
- this PR was added in addition to [pytensor-feedstock/pull/5](https://github.com/AnacondaRecipes/pytensor-feedstock/pull/5) to support `py39` and `py310`, since `2.23` only supported `py>=311`

[PKG-6364]: https://anaconda.atlassian.net/browse/PKG-6364?