### PR TITLE
rebuild 2.12.3 with cxx for osx

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,6 +69,7 @@ test:
     # this flag prevents a known issue with macOS clang++ throwing errors when narrowing types in implicit casts
     - export PYTENSOR_FLAGS="gcc__cxxflags=-Wno-c++11-narrowing"  # [osx]
     - python check-for-warnings.py allowed-warnings-base.txt
+    - export PYTENSOR_FLAGS="gcc__cxxflags=-Wno-c++11-narrowing"  # [osx]
     # skipping test_config_pickling because of a regex error which seems to be related to pickle
     # AssertionError: Regex pattern did not match. Regex: "Can't pickle local object"
     # Input: "Can't get local object 'test_config_pickling.<locals>.<lambda>'" 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,12 @@ source:
 
 build:
   number: 2
+  # skip py312 because of numpy 1.26 incompatibility
+  skip: True  # [py>311]
   script:
     - python -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
-    - pytensor-cache = pytensor.bin.pytensor_cache:main
-  skip: True #  [py<=310]
+    - pytensor-cache = bin.pytensor_cache:main
 
 requirements:
   build:
@@ -60,17 +61,12 @@ test:
     - check-for-warnings.py
     - allowed-warnings-base.txt
   commands:
+    - pytensor-cache help
     - pip check
     # this flag prevents a known issue with macOS clang++ throwing errors when narrowing types in implicit casts
     - export PYTENSOR_FLAGS="gcc__cxxflags=-Wno-c++11-narrowing"  # [osx]
     - python check-for-warnings.py allowed-warnings-base.txt
-    # this flag prevents a known issue with macOS clang++ throwing errors when narrowing types in implicit casts
-    - export PYTENSOR_FLAGS="gcc__cxxflags=-Wno-c++11-narrowing"  # [osx]
-    # skipping test_config_pickling because of a regex error which seems to be related to pickle
-    # AssertionError: Regex pattern did not match. Regex: "Can't pickle local object"
-    # Input: "Can't get local object 'test_config_pickling.<locals>.<lambda>'" 
-    - python -m pytest -k "not test_config_pickling" tests/test_breakpoint.py tests/test_config.py tests/test_gradient.py tests/test_ifelse.py tests/test_raise_op.py tests/test_rop.py tests/test_updates.py
-    - python -m pytest tests/test_printing.py  # [osx]
+    - python -m pytest tests/test_breakpoint.py tests/test_config.py tests/test_gradient.py tests/test_ifelse.py tests/test_raise_op.py tests/test_rop.py tests/test_updates.py
 
 about:
   home: https://github.com/pymc-devs/pytensor

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ requirements:
     - cons
     - typing_extensions
     - setuptools >=48.0.0
+    # necessary to compile code at runtime
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/pymc-devs/{{ name }}/archive/refs/tags/rel-{{ version }}.tar.gz
+  url: https://github.com/pymc-devs/{{ name }}/archive/refs/tags/rel-{{ version }}.tar.gz\
   sha256: a1c436c67376436d2030742434cae7ff450a07c207c352f26ac958b0fb60142e
 
 build:
@@ -17,6 +17,7 @@ build:
     - python -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - pytensor-cache = bin.pytensor_cache:main
+  skip: True #  [py<=310]
 
 requirements:
   build:
@@ -63,7 +64,6 @@ test:
     - check-for-warnings.py
     - allowed-warnings-base.txt
   commands:
-    - pytensor-cache help
     - pip check
     # this flag prevents a known issue with macOS clang++ throwing errors when narrowing types in implicit casts
     - export PYTENSOR_FLAGS="gcc__cxxflags=-Wno-c++11-narrowing"  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,7 +81,7 @@ about:
     PyTensor is a Python library that allows you to define, optimize/rewrite, and evaluate mathematical expressions
     involving multi-dimensional arrays efficiently.
   dev_url: https://github.com/pymc-devs/pytensor/
-  doc_url: https://pytensor.readthedocs.io/en/latest/
+  doc_url: https://pytensor.readthedocs.io
 
 extra:
   recipe-maintainers:
@@ -92,4 +92,3 @@ extra:
   skip-lints:
     - host_section_needs_exact_pinnings
     - python_build_tool_in_run
-    - documentation_specifies_language

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/pymc-devs/{{ name }}/archive/refs/tags/rel-{{ version }}.tar.gz\
+  url: https://github.com/pymc-devs/{{ name }}/archive/refs/tags/rel-{{ version }}.tar.gz
   sha256: a1c436c67376436d2030742434cae7ff450a07c207c352f26ac958b0fb60142e
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,6 +69,7 @@ test:
     # this flag prevents a known issue with macOS clang++ throwing errors when narrowing types in implicit casts
     - export PYTENSOR_FLAGS="gcc__cxxflags=-Wno-c++11-narrowing"  # [osx]
     - python check-for-warnings.py allowed-warnings-base.txt
+    # this flag prevents a known issue with macOS clang++ throwing errors when narrowing types in implicit casts
     - export PYTENSOR_FLAGS="gcc__cxxflags=-Wno-c++11-narrowing"  # [osx]
     # skipping test_config_pickling because of a regex error which seems to be related to pickle
     # AssertionError: Regex pattern did not match. Regex: "Can't pickle local object"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
   script:
     - python -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
-    - pytensor-cache = bin.pytensor_cache:main
+    - pytensor-cache = pytensor.bin.pytensor_cache:main
   skip: True #  [py<=310]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,10 @@ test:
     # this flag prevents a known issue with macOS clang++ throwing errors when narrowing types in implicit casts
     - export PYTENSOR_FLAGS="gcc__cxxflags=-Wno-c++11-narrowing"  # [osx]
     - python check-for-warnings.py allowed-warnings-base.txt
-    - python -m pytest tests/test_breakpoint.py tests/test_config.py tests/test_gradient.py tests/test_ifelse.py tests/test_raise_op.py tests/test_rop.py tests/test_updates.py
+    # skipping test_config_pickling because of a regex error which seems to be related to pickle
+    # AssertionError: Regex pattern did not match. Regex: "Can't pickle local object"
+    # Input: "Can't get local object 'test_config_pickling.<locals>.<lambda>'" 
+    - python -m pytest -k "not test_config_pickling" tests/test_breakpoint.py tests/test_config.py tests/test_gradient.py tests/test_ifelse.py tests/test_raise_op.py tests/test_rop.py tests/test_updates.py
     - python -m pytest tests/test_printing.py  # [osx]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,7 @@ source:
   sha256: a1c436c67376436d2030742434cae7ff450a07c207c352f26ac958b0fb60142e
 
 build:
-  number: 1
-  # skip py312 because of numpy 1.26 incompatibility
-  skip: True  # [py>311]
+  number: 2
   script:
     - python -m pip install . -vv --no-deps --no-build-isolation
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,9 +56,6 @@ test:
     - pip
     - pytest
     - pre-commit
-    - pytest-cov >=2.6.1
-    - coverage >=5.1
-    - pytest-benchmark
   source_files:
     - tests
   files:


### PR DESCRIPTION
pytensor 2.12.3

**Destination channel:** Default

### Links

- [PKG-6364]
- dev_url:        https://github.com/pymc-devs/pytensor//tree/rel-2.12.3
- conda_forge:    None
- pypi:           https://pypi.org/project/pytensor/2.12.3
- pypi inspector: https://inspector.pypi.io/project/pytensor/2.12.3

### Related PRs
- https://github.com/AnacondaRecipes/causalimpact-feedstock/pull/1
- https://github.com/AnacondaRecipes/pytensor-feedstock/pull/5
- https://github.com/AnacondaRecipes/pytensor-feedstock/pull/7

### Explanation of changes:

- reopened after [pytensor-feedstock/pull/7](https://github.com/AnacondaRecipes/pytensor-feedstock/pull/7)
- `compiler('c')` and `compiler('cxx')` was added in run to support the compilation of code at runtime
- added a flag preventing a known issue with macOS clang++ throwing errors when narrowing types in implicit casts
- this PR was added in addition to [pytensor-feedstock/pull/5](https://github.com/AnacondaRecipes/pytensor-feedstock/pull/5) to support `py39` and `py310`, since `2.23` only supported `py>=311`

[PKG-6364]: https://anaconda.atlassian.net/browse/PKG-6364?