### PR TITLE
pytensor 2.36.1: add support for py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytensor" %}
-{% set version = "2.36.0" %}
+{% set version = "2.36.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pymc-devs/{{ name }}/archive/refs/tags/rel-{{ version }}.tar.gz
-  sha256: 11c845f25de0f1840bc199c1df4c533f9a57d2f525d42f80c2733748a4ddcff9
+  sha256: cfb4489a7f651f1b507342d8fdb41a41defa020399916680863bd45e7bfb8d37
   patches:
     - 0001-patch-pyproject.toml.patch
 
@@ -18,7 +18,7 @@ build:
   entry_points:
     - pytensor-cache = pytensor.bin.pytensor_cache:main
   # upstream requirement
-  skip: true  # [py<310 or py>=315]
+  skip: true  # [py<311 or py>=315]
 
 requirements:
   build:
@@ -130,7 +130,6 @@ test:
     - pytensor.tensor.blas
     - pytensor.tensor.blas_c
     - pytensor.tensor.blas_headers
-    - pytensor.tensor.blas_scipy
     - pytensor.tensor.blockwise
     - pytensor.tensor.einsum
     - pytensor.tensor.elemwise
@@ -138,7 +137,6 @@ test:
     - pytensor.tensor.extra_ops
     - pytensor.tensor.functional
     - pytensor.tensor.interpolate
-    - pytensor.tensor.io
     - pytensor.tensor.math
     - pytensor.tensor.nlinalg
     - pytensor.tensor.pad
@@ -164,7 +162,8 @@ test:
     - pip
     - pytest
     - pre-commit
-    - jax
+    # jax is not available for Python 3.14 on the main channel.
+    - jax  # [py<314]
   source_files:
     - tests
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "pytensor" %}
 {% set version = "2.31.7" %}
-{% set deselect_tests = " --deselect=tests/test_gradient.py::TestJacobian::test_benchmark" %}
 
 package:
   name: {{ name|lower }}
@@ -24,6 +23,7 @@ build:
 requirements:
   build:
     - git  # [linux]
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
@@ -56,6 +56,8 @@ requirements:
     - numba >=0.57
 
 # E   fixture 'benchmark' not found
+{% set deselect_tests = " --deselect=tests/test_gradient.py::TestJacobian::test_benchmark" %}
+
 test:
   imports:
     - pytensor

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pymc-devs/{{ name }}/archive/refs/tags/rel-{{ version }}.tar.gz
-  sha256: 41b89de1c20adb04381c61b22527ddc11d401d83c276c050427a12676b5c4dbe
+  sha256: 11c845f25de0f1840bc199c1df4c533f9a57d2f525d42f80c2733748a4ddcff9
   patches:
     - 0001-patch-pyproject.toml.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytensor" %}
-{% set version = "2.31.7" %}
+{% set version = "2.36.0" %}
 
 package:
   name: {{ name|lower }}
@@ -18,7 +18,7 @@ build:
   entry_points:
     - pytensor-cache = pytensor.bin.pytensor_cache:main
   # upstream requirement
-  skip: true  # [py<310 or py>=314]
+  skip: true  # [py<310 or py>=315]
 
 requirements:
   build:
@@ -38,8 +38,9 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.17.0
+    - numpy >=2.0
     - scipy >=1,<2
+    - numba >=0.57,<1
     - filelock >=3.15
     - etuples
     - logical-unification
@@ -52,8 +53,6 @@ requirements:
   run_constrained:
     # rtd
     - sphinx >=5.1.0,<6
-    # numba
-    - numba >=0.57
 
 # E   fixture 'benchmark' not found
 {% set deselect_tests = " --deselect=tests/test_gradient.py::TestJacobian::test_benchmark" %}
@@ -166,8 +165,6 @@ test:
     - pytest
     - pre-commit
     - jax
-    - numba
-    - pytorch
   source_files:
     - tests
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-patch-pyproject.toml.patch
 
 build:
-  number: 1
+  number: 0
   script:
     - python -m pip install . -vv --no-deps --no-build-isolation
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "pytensor" %}
 {% set version = "2.31.7" %}
+{% set deselect_tests = " --deselect=tests/test_gradient.py::TestJacobian::test_benchmark" %}
 
 package:
   name: {{ name|lower }}
@@ -12,21 +13,19 @@ source:
     - 0001-patch-pyproject.toml.patch
 
 build:
-  number: 0
+  number: 1
   script:
     - python -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - pytensor-cache = pytensor.bin.pytensor_cache:main
   # upstream requirement
-  skip: True  # [py<310 or py>=314]
+  skip: true  # [py<310 or py>=314]
 
 requirements:
   build:
     - git  # [linux]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - patch     # [not win]
-    - m2-patch  # [win]
   host:
     - python
     - cython
@@ -57,8 +56,6 @@ requirements:
     - numba >=0.57
 
 # E   fixture 'benchmark' not found
-{% set deselect_tests = " --deselect=tests/test_gradient.py::TestJacobian::test_benchmark" %}
-
 test:
   imports:
     - pytensor


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-11341) 
- [Upstream repository](https://github.com/pymc-devs/pytensor/blob/rel-2.36.1/pyproject.toml)

### Explanation of changes:

- Skip py<311
- Add stdlib_c
- Update runtime pinnings
- Disable jax for py314, it is not available for Python 3.14 on the main channel.

### Notes:

-